### PR TITLE
Add the images being pushed

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -10,7 +10,7 @@ class SlackDockerApp < Sinatra::Base
   end
   post "/*" do
     docker = JSON.parse(request.body.read)
-    slack = {text: "[<#{docker['repository']['repo_url']}|#{docker['repository']['repo_name']}>] new image build complete."}
+    slack = {text: "[<#{docker['repository']['repo_url']}|#{docker['repository']['repo_name']}#{docker['push_data']['images']}>] new image build complete."}
     RestClient.post("https://hooks.slack.com/#{params[:splat].first}", payload: slack.to_json){ |response, request, result, &block|
         RestClient.post(docker['callback_url'], {state: response.code==200?"success":"error"}.to_json, :content_type => :json)
     }


### PR DESCRIPTION
Just a quick change to include the image tag being built. If a repository has multiple tags in an automated build, they'll all show up as the same notification.
